### PR TITLE
fix `dns create --proxied` subcommand help description

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -244,7 +244,7 @@ fn main() {
                     )
                     .arg(Arg::with_name("proxied")
                         .long("proxied")
-                        .help("Used with some records like MX and SRV to determine priority")
+                        .help("Whether the record would be proxied by Cloudflare")
                     )
                     .arg(Arg::with_name("priority")
                         .long("priority")


### PR DESCRIPTION
### before
```
$ cflare dns create --help

USAGE:
    cflare dns create [FLAGS] [OPTIONS] <name> --content <content> --ttl <ttl> --type <type> --zone <zone>
...
FLAGS:
...
        --proxied    Used with some records like MX and SRV to determine priority
...
```

### after
```
$ cflare dns create --help

USAGE:
    cflare dns create [FLAGS] [OPTIONS] <name> --content <content> --ttl <ttl> --type <type> --zone <zone>
...
FLAGS:
...
        --proxied    Whether the record would be proxied by Cloudflare
...
```

awesome work btw, I am pretty happy with this tool so far